### PR TITLE
download PDB structures via HTTPS instead of FTP

### DIFF
--- a/pros2vi_gui.py
+++ b/pros2vi_gui.py
@@ -72,7 +72,7 @@ def submit():
     if filename == '':
         if not os.path.isfile(f'uploads/{pdb_name}.cif'):
             try:
-                pdbl = PDBList()
+                pdbl = PDBList(server='https://files.wwpdb.org')
                 pdbl.retrieve_pdb_file(pdb_name, pdir='uploads', file_format='mmCif')
             except Exception as e:
                 return redirect(url_for('error_page'))


### PR DESCRIPTION
The default has changed in newer versions of biopython [1] and PDB has deprecated the use of FTP File Download protocol as of November 1, 2024 and apperantly taken ftp.wwpdb.org offline.

[1] https://github.com/biopython/biopython/blob/master/NEWS.rst#28-june-2024-biopython-184
[2] https://www.wwpdb.org/news/news?year=2024#66d85fda6d29b84962cd3703