### PR TITLE
Update pillow version to 12.0.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ MarkupSafe==2.1.5
 numpy==1.26.4
 pdf2image==1.17.0
 pdfkit==1.0.0
-pillow==10.3.0
+pillow==12.0.0
 pycparser==2.22
 requests==2.32.3
 six==1.16.0


### PR DESCRIPTION
The Pillow version was upgraded to 12.0.0 from 10.3.0, as Python 3.13 does not support any Pillow version below 11.0.0.